### PR TITLE
Update date time parsing in `pollutants.ipynb`

### DIFF
--- a/Section-02-Datasets/pollutants.ipynb
+++ b/Section-02-Datasets/pollutants.ipynb
@@ -419,9 +419,9 @@
     "# cast date and time variable as datetime\n",
     "# replace . by : to transform to datetime format\n",
     "\n",
-    "data['Date_Time'] = data['Date_Time'].str.replace('.', ':', regex=True)\n",
+    "data['Date_Time'] = data['Date_Time'].str.replace('.', ':', regex=False)\n",
     "\n",
-    "data['Date_Time'] = pd.to_datetime(data['Date_Time'])\n",
+    "data['Date_Time'] = pd.to_datetime(data['Date_Time'], format='mixed')\n",
     "\n",
     "data.head()"
    ]


### PR DESCRIPTION
# Motivation
When running the `pollutants.ipynb` notebook, I received an error in the cell that adjusts `Date_Time` formatting and parses the value as a `datetime`. Here is the text and screenshot of the error:

![Screenshot 2023-05-06 at 5 15 24 PM](https://user-images.githubusercontent.com/808389/236646826-48f3d830-0aa1-4ead-ab77-e65ef0830fd2.png)

raw text: `DateParseError: Unknown datetime string format, unable to parse: :::::::::::::::::::, at position 0`

# Changes

- Modifies the `regex` argument to be `True` for the `replace` method call
- Specifies the format type as `mixed` in the call to `pd.to_datetime`